### PR TITLE
feat(langchain): upgrade deepagents fetch integration

### DIFF
--- a/examples/integrations/langchain/deepagents-browserbase/README.md
+++ b/examples/integrations/langchain/deepagents-browserbase/README.md
@@ -37,8 +37,6 @@ The sample defaults to:
 
 You can override either with environment variables.
 
-The fetch tool now defaults to `format="markdown"` so the main Deep Agent gets cleaner LLM-ready content from Browserbase Fetch Extract. For structured extraction on non-JS pages, the tool also supports `format="json"` with a JSON schema string.
-
 ## Install
 
 ```bash

--- a/examples/integrations/langchain/deepagents-browserbase/README.md
+++ b/examples/integrations/langchain/deepagents-browserbase/README.md
@@ -11,7 +11,7 @@ It intentionally does **not** route the agent through the Browserbase CLI. Deep 
 ## Architecture
 
 - `browserbase_search`: fast discovery with Browserbase Search
-- `browserbase_fetch`: cheap page retrieval with Browserbase Fetch
+- `browserbase_fetch`: Browserbase Fetch / Fetch Extract for raw, markdown, or structured JSON retrieval
 - `browserbase_rendered_extract`: Stagehand-backed rendered extraction for JS-heavy pages
 - `browserbase_interactive_task`: a Stagehand `agent().execute(...)` workflow for clicks, typing, login, or form submission
 - `browser-specialist` subagent: isolates browser-heavy work from the main planner
@@ -36,6 +36,8 @@ The sample defaults to:
 - Stagehand interactive-agent model: `anthropic/claude-sonnet-4-6`
 
 You can override either with environment variables.
+
+The fetch tool now defaults to `format="markdown"` so the main Deep Agent gets cleaner LLM-ready content from Browserbase Fetch Extract. For structured extraction on non-JS pages, the tool also supports `format="json"` with a JSON schema string.
 
 ## Install
 
@@ -87,11 +89,14 @@ This is the right place to put human approval in a Deep Agents + Browserbase des
 ## Notes
 
 - The interactive tool now uses `stagehand.agent().execute(...)` instead of a single `sessions.act(...)` call. That makes it better suited to genuine multi-step browser tasks.
+- Browserbase Fetch supports `raw`, `markdown`, and `json` output in the Python SDK starting with `browserbase` `1.11.0`, which is why this example now requires that version or newer.
 - Browserbase’s Stagehand quickstart documents that Model Gateway works with just `BROWSERBASE_API_KEY` for Stagehand browser workflows.
 - I did not hardcode a Browserbase model-gateway URL for the LangChain model client because I did not find an official doc page in the Browserbase docs that specifies a general-purpose OpenAI-compatible endpoint for LangChain. The sample therefore accepts `DEEPAGENT_BASE_URL` or `OPENAI_BASE_URL` explicitly.
 
 ## Suggested prompts
 
 - `Research Browserbase Search, Fetch, and browser sessions. Give me a decision tree with citations.`
+- `Use browserbase_fetch with markdown output on https://docs.browserbase.com/platform/fetch/overview and summarize the fetch limits.`
+- `Use browserbase_fetch with JSON output to extract the page title and one-sentence summary from https://www.browserbase.com/.`
 - `Open docs.browserbase.com and extract the limits of the Fetch API from the rendered docs page.`
 - `Go to example.com and tell me whether any interactive action would be required to complete the task.`

--- a/examples/integrations/langchain/deepagents-browserbase/browser_tools.py
+++ b/examples/integrations/langchain/deepagents-browserbase/browser_tools.py
@@ -111,10 +111,47 @@ def browserbase_search(query: str, num_results: int = 5) -> str:
 
 
 @tool
-def browserbase_fetch(url: str, use_proxy: bool = False, max_chars: int = 12000) -> str:
+def browserbase_fetch(
+    url: str,
+    format: str = "markdown",
+    schema: str = "",
+    use_proxy: bool = False,
+    allow_redirects: bool = False,
+    allow_insecure_ssl: bool = False,
+    max_chars: int = 12000,
+) -> str:
     """Fetch page content without a browser session. Best for static pages and quick reads."""
     bb = _browserbase_client()
-    response = bb.fetch_api.create(url=url, proxies=use_proxy)
+    normalized_format = format.strip().lower() or "markdown"
+    if normalized_format not in {"raw", "markdown", "json"}:
+        raise ValueError("format must be one of: raw, markdown, json")
+
+    parsed_schema: dict[str, Any] | None = None
+    if schema.strip():
+        try:
+            loaded_schema = json.loads(schema)
+        except json.JSONDecodeError as exc:
+            raise ValueError("schema must be valid JSON") from exc
+        if not isinstance(loaded_schema, dict):
+            raise ValueError("schema must decode to a JSON object")
+        parsed_schema = loaded_schema
+
+    if normalized_format == "json" and parsed_schema is None:
+        raise ValueError("schema is required when format='json'")
+    if normalized_format != "json" and parsed_schema is not None:
+        raise ValueError("schema can only be used when format='json'")
+
+    request: dict[str, Any] = {
+        "url": url,
+        "format": normalized_format,
+        "proxies": use_proxy,
+        "allow_redirects": allow_redirects,
+        "allow_insecure_ssl": allow_insecure_ssl,
+    }
+    if parsed_schema is not None:
+        request["schema"] = parsed_schema
+
+    response = bb.fetch_api.create(**request)
     content = getattr(response, "content", "")
     content_type = (
         getattr(response, "content_type", None)
@@ -123,20 +160,33 @@ def browserbase_fetch(url: str, use_proxy: bool = False, max_chars: int = 12000)
     ).lower()
 
     title = ""
-    text = str(content)[:max_chars]
-    if "html" in content_type:
-        title, text = _html_to_text(str(content), max_chars=max_chars)
+    text = ""
+    structured_content: Any = None
+
+    if normalized_format == "json":
+        structured_content = _normalize(content)
+    else:
+        text = str(content)[:max_chars]
+        if normalized_format == "raw" and "html" in content_type:
+            title, text = _html_to_text(str(content), max_chars=max_chars)
 
     return _json(
         {
             "url": url,
+            "format": normalized_format,
+            "schema": parsed_schema,
+            "used_proxy": use_proxy,
+            "allow_redirects": allow_redirects,
+            "allow_insecure_ssl": allow_insecure_ssl,
             "status_code": getattr(response, "status_code", None)
             or getattr(response, "statusCode", None),
+            "headers": getattr(response, "headers", None),
             "content_type": getattr(response, "content_type", None)
             or getattr(response, "contentType", None),
             "encoding": getattr(response, "encoding", None),
             "title": title,
             "text": text,
+            "content": structured_content,
         }
     )
 

--- a/examples/integrations/langchain/deepagents-browserbase/main.py
+++ b/examples/integrations/langchain/deepagents-browserbase/main.py
@@ -24,7 +24,8 @@ SYSTEM_PROMPT = """You are a research-oriented Deep Agent with Browserbase tools
 
 Workflow rules:
 - Start with browserbase_search for discovery unless the user already gave you a precise URL.
-- Prefer browserbase_fetch for quick reads of static pages.
+- Prefer browserbase_fetch with markdown output for quick reads of static pages.
+- Use browserbase_fetch with JSON output plus a schema when you need structured extraction from a non-JS page.
 - Delegate JS-heavy, rendered, or multi-step browsing work to the browser-specialist subagent.
 - Use browserbase_rendered_extract for read-only browser work on rendered pages.
 - Use browserbase_interactive_task only when the task requires clicking, typing, login, or form submission.
@@ -209,7 +210,7 @@ def parse_args() -> argparse.Namespace:
         "query",
         nargs="?",
         default=(
-            "Research the Browserbase Search API and explain when to use Search, Fetch, "
+            "Research the Browserbase Search and Fetch APIs and explain when to use Search, Fetch, "
             "and a full browser session. Cite the URLs you used."
         ),
     )

--- a/examples/integrations/langchain/deepagents-browserbase/requirements.txt
+++ b/examples/integrations/langchain/deepagents-browserbase/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4>=4.13.0
-browserbase>=1.8.0
-deepagents>=0.0.5
-langchain-openai>=0.3.0
+browserbase>=1.11.0
+deepagents>=0.6.3
+langchain-openai>=1.2.1
 python-dotenv>=1.0.0
-stagehand>=3.19.5
+stagehand>=3.20.0


### PR DESCRIPTION
## Summary
- upgrade the LangChain Deep Agents example to the latest Browserbase/Deep Agents package floors
- switch `browserbase_fetch` to default to Browserbase Fetch Extract markdown output and add support for raw and structured JSON fetch modes
- update the Deep Agent prompting and README so the example prefers markdown fetch and documents the new fetch behavior

## Verification
- `python3 -m py_compile examples/integrations/langchain/deepagents-browserbase/browser_tools.py examples/integrations/langchain/deepagents-browserbase/main.py`

Linear: GRO-1524