### PR TITLE
[STG-2117] fix: register OpenClaw Browserbase CLI command

### DIFF
--- a/.changeset/calm-rivers-listen.md
+++ b/.changeset/calm-rivers-listen.md
@@ -1,0 +1,5 @@
+---
+'@browserbasehq/openclaw-browserbase': patch
+---
+
+Register the Browserbase OpenClaw CLI command with explicit command metadata so `openclaw browserbase ...` commands are discoverable.

--- a/packages/openclaw-browserbase/src/index.ts
+++ b/packages/openclaw-browserbase/src/index.ts
@@ -197,7 +197,7 @@ function registerCli(
   api: OpenClawPluginApi,
   logger: OpenClawPluginApi['logger']
 ): void {
-  api.registerCli(({ program }: { program: any }) => {
+  const registerBrowserbaseCommands = ({ program }: { program: any }) => {
     const browserbase = program
       .command('browserbase')
       .description('Browserbase plugin setup and credential helpers');
@@ -453,7 +453,9 @@ function registerCli(
       .action((options: any) => {
         console.log(resolveConfigPath(options.config));
       });
-  });
+  };
+
+  api.registerCli(registerBrowserbaseCommands, { commands: ['browserbase'] });
 }
 
 let didStartupPrompt = false;


### PR DESCRIPTION
## Summary

- Register the Browserbase OpenClaw CLI handler with explicit `commands` metadata.
- Add a patch changeset for `@browserbasehq/openclaw-browserbase` so the fix can ship as a patch release.

## Issue

Fixes browserbase/openclaw-browserbase#4.
Linear: https://linear.app/browserbase/issue/STG-2117/fix-openclaw-browserbase-cli-command-registration

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `pnpm --filter @browserbasehq/openclaw-browserbase build` | `tsc` completed successfully. | Proves the package builds after adding CLI registration metadata. |
| `pnpm --filter @browserbasehq/openclaw-browserbase check-types` | `tsc --noEmit` completed successfully. | Proves the TypeScript surface type-checks without emitting artifacts. |
| `pnpm exec prettier --check packages/openclaw-browserbase/src/index.ts .changeset/calm-rivers-listen.md` | `All matched files use Prettier code style!` | Proves touched files match repo formatting. |
| `pnpm changeset status --since=origin/main` | Reported `@browserbasehq/openclaw-browserbase` under `Packages to be bumped at patch`. | Proves the release metadata is present and targets the package requested for patch release. |
| `pnpm --dir packages/openclaw-browserbase pack --pack-destination <temp artifact>` then isolated `HOME=<temp home> npx -y openclaw@2026.4.14 plugins install <local tarball>; npx -y openclaw@2026.4.14 plugins inspect browserbase; npx -y openclaw@2026.4.14 browserbase status --json` | Install succeeded; inspect showed `Status: loaded` and `CLI commands: browserbase`; `browserbase status --json` returned JSON with `configured: false`, default Browserbase API URL, and no unknown-command error. | Exercises the reporter's OpenClaw version against the locally packed package and proves the `browserbase` CLI command now registers. Does not exercise the interactive credential prompt itself. |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small registration/metadata change with no credential, auth, or runtime logic changes; validated by build, typecheck, and isolated OpenClaw install/inspect.
> 
> **Overview**
> Fixes **CLI discovery** for the Browserbase OpenClaw plugin by passing **`commands: ['browserbase']`** when registering the CLI handler, so `openclaw browserbase ...` (setup, status, skills, env, where) shows up instead of failing as an unknown command.
> 
> The handler is refactored from an inline callback to **`registerBrowserbaseCommands`** with the same subcommands; behavior is unchanged aside from registration. A **patch changeset** records the release for `@browserbasehq/openclaw-browserbase`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abc5ddc06d7eb3867a847e4bcbe6a8819efc2b35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->