### PR TITLE
fix(openclaw-browserbase): repoint skill sync to browse-plugin

### DIFF
--- a/.changeset/openclaw-repoint-skill-sync.md
+++ b/.changeset/openclaw-repoint-skill-sync.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/openclaw-browserbase": patch
+---
+
+Repoint dynamic skill sync from the stale `browserbase/skills` browser-automation skill to the current `browserbase/browse-plugin` browse CLI skill.

--- a/packages/openclaw-browserbase/README.md
+++ b/packages/openclaw-browserbase/README.md
@@ -6,7 +6,7 @@ It provides:
 
 - interactive Browserbase credential setup,
 - config status/env helpers,
-- dynamic skill sync from `github:browserbase/skills`.
+- dynamic skill sync from `github:browserbase/browse-plugin`.
 
 ## Install
 
@@ -26,8 +26,8 @@ openclaw plugins install -l .
 openclaw browserbase setup
 ```
 
-By default setup will also sync Browserbase skills from `browserbase/skills` into
-`~/.openclaw/skills`.
+By default setup will also sync Browserbase skills from `browserbase/browse-plugin`
+into `~/.openclaw/skills`.
 
 You can manage skill sync directly:
 
@@ -49,7 +49,7 @@ openclaw browserbase env --format dotenv       # dotenv output
 openclaw browserbase env --format json         # JSON output
 openclaw browserbase where                     # config file path used
 openclaw browserbase skills status             # check dynamic skills sync status
-openclaw browserbase skills sync               # download/update skills from browserbase/skills
+openclaw browserbase skills sync               # download/update skills from browserbase/browse-plugin
 ```
 
 Legacy CLI alias support remains:
@@ -64,10 +64,9 @@ OpenClaw installs plugins with lifecycle scripts disabled, so plugin install hoo
 
 This plugin instead syncs skills during setup and (optionally) on startup when missing:
 
-- `browser-automation`
-- `functions`
+- `browse` — the canonical `browse` CLI skill
 
-Source of truth: [https://github.com/browserbase/skills](https://github.com/browserbase/skills)
+Source of truth: [https://github.com/browserbase/browse-plugin](https://github.com/browserbase/browse-plugin)
 
 ## Development
 
@@ -83,5 +82,5 @@ pnpm test
 - OpenClaw Skills Config: https://docs.openclaw.ai/tools/skills-config
 - OpenClaw Plugin System: https://docs.openclaw.ai/tools/plugin
 - OpenClaw Plugin Manifest: https://docs.openclaw.ai/plugins/manifest
-- Browserbase skills reference: https://github.com/browserbase/skills
+- Browserbase skills reference: https://github.com/browserbase/browse-plugin
 - Example plugin reference: https://github.com/pepicrft/clawd-plugin-ralph

--- a/packages/openclaw-browserbase/src/index.ts
+++ b/packages/openclaw-browserbase/src/index.ts
@@ -173,13 +173,13 @@ async function runSkillsSync(options?: {
 
     if (!options?.silent) {
       console.log(
-        `Synced Browserbase skills from browserbase/skills@${result.ref} to ${result.targetRoot}`
+        `Synced Browserbase skills from browserbase/browse-plugin@${result.ref} to ${result.targetRoot}`
       );
       console.log(`Files updated: ${result.filesWritten.length}`);
     }
 
     logger?.info(
-      `browserbase: synced skills from browserbase/skills@${result.ref} to ${result.targetRoot}`
+      `browserbase: synced skills from browserbase/browse-plugin@${result.ref} to ${result.targetRoot}`
     );
     return true;
   } catch (error) {
@@ -214,7 +214,11 @@ function registerCli(
         false
       )
       .option('--skills-dir <path>', 'Override skills target directory')
-      .option('--skills-ref <ref>', 'Git ref for browserbase/skills', 'main')
+      .option(
+        '--skills-ref <ref>',
+        'Git ref for browserbase/browse-plugin',
+        'main'
+      )
       .action(async (options: any) => {
         const configPath = resolveConfigPath(options.config);
         const shouldSyncSkills = !options.skipSkillsSync;
@@ -344,14 +348,14 @@ function registerCli(
     const browserbaseSkills = browserbase
       .command('skills')
       .description(
-        'Manage Browserbase skills synced from github:browserbase/skills'
+        'Manage Browserbase skills synced from github:browserbase/browse-plugin'
       );
 
     browserbaseSkills
       .command('sync')
       .description('Download/update Browserbase skills into ~/.openclaw/skills')
       .option('--dir <path>', 'Override skills target directory')
-      .option('--ref <ref>', 'Git ref for browserbase/skills', 'main')
+      .option('--ref <ref>', 'Git ref for browserbase/browse-plugin', 'main')
       .action(async (options: any) => {
         const targetRoot = resolveSkillsRoot(options.dir);
         const ref =
@@ -478,7 +482,7 @@ async function maybePromptOnStartup(
     !hasBrowserbaseSkills(managedSkillsRoot)
   ) {
     logger.info(
-      `browserbase: Browserbase skills not found in ${managedSkillsRoot}; syncing from browserbase/skills`
+      `browserbase: Browserbase skills not found in ${managedSkillsRoot}; syncing from browserbase/browse-plugin`
     );
     await runSkillsSync({
       targetRoot: managedSkillsRoot,

--- a/packages/openclaw-browserbase/src/skills-sync.ts
+++ b/packages/openclaw-browserbase/src/skills-sync.ts
@@ -7,7 +7,8 @@ import { pipeline } from 'node:stream/promises';
 
 import { x } from 'tar';
 
-const TARBALL_BASE = 'https://codeload.github.com/browserbase/skills/tar.gz';
+const TARBALL_BASE =
+  'https://codeload.github.com/browserbase/browse-plugin/tar.gz';
 const DEFAULT_SKILLS_REF = 'main';
 
 /**
@@ -114,7 +115,7 @@ export async function syncBrowserbaseSkills(options?: {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'bb-skills-sync-'));
 
   try {
-    // The tarball has a root directory like "skills-<sha>/" containing "skills/browser/", etc.
+    // The tarball has a root directory like "browse-plugin-<sha>/" containing "skills/browse/", etc.
     // We want to strip: (1) the repo root prefix, (2) the "skills/" prefix.
     // That's strip: 2, and we filter to only entries under the "skills/" subtree.
     await pipeline(
@@ -123,7 +124,7 @@ export async function syncBrowserbaseSkills(options?: {
         cwd: tmpDir,
         strip: 2,
         filter: entryPath => {
-          // Entry paths look like: "skills-<sha>/skills/browser/SKILL.md"
+          // Entry paths look like: "browse-plugin-<sha>/skills/browse/SKILL.md"
           // After the first "/" is the repo-relative path.
           const repoRelative = entryPath.replace(/^[^/]+\//, '');
           return repoRelative.startsWith(SKILLS_SOURCE_PREFIX);


### PR DESCRIPTION
Linear: [STG-2529](https://linear.app/browserbase/issue/STG-2529/repoint-openclaw-browserbase-skill-sync-from-browserbaseskills-to)

## What

`@browserbasehq/openclaw-browserbase`'s dynamic skill sync (`skills-sync.ts`) pulled the `browser-automation` skill from `browserbase/skills`, which is stale — it references the deprecated `@browserbasehq/browse-cli` install command. This repoints it to `browserbase/browse-plugin`'s current `skills/browse/SKILL.md`, the actively-maintained source for the `browse` CLI skill.

Both repos use the same top-level `skills/` extraction convention, so this is a URL swap in `TARBALL_BASE` plus updated user-facing strings/docs (`src/index.ts`, `README.md`) — no change to the sync mechanism itself.

## Merge-order dependency — resolved

[browserbase/browse-plugin#3](https://github.com/browserbase/browse-plugin/pull/3) added the top-level `skills/browse/` directory to `browse-plugin`'s `main` (previously the old nested `plugins/browse/skills/browse/` layout, pre-flatten). **#3 merged 2026-07-16**, so `browse-plugin`'s `main` now has the `skills/` dir this PR's sync target expects — this PR is unblocked and ready to merge on its own.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `pnpm run check-types` (this package) | Clean, exit 0 | Confirms the refactor didn't break typing. |
| `pnpm run build` | Clean, exit 0 | Confirms it compiles. |
| Real `syncBrowserbaseSkills({ ref: 'main' })` against `browserbase/browse-plugin` main (built `dist/skills-sync.js`, run 2026-07-23 post-#3-merge) | `filesWritten: ['<tmp>/browse/SKILL.md']`, 372-line SKILL.md with correct `browse` frontmatter | **Proves the fix works end-to-end against the current default branch** — no further upstream changes needed. |
| `grep -rn "browserbase/skills" src/ README.md` | No matches | Confirms no stale references were missed. |

Test artifacts cleaned up after; no leftover state in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
