### PR TITLE
feat(langchain): add Stagehand code-mode integration

### DIFF
--- a/.github/workflows/stagehand-codemode.yml
+++ b/.github/workflows/stagehand-codemode.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/stagehand-codemode.yml'
       - 'examples/integrations/crewai/stagehand-codemode/**'
+      - 'examples/integrations/langchain/stagehand-codemode/**'
       - 'examples/integrations/mastra/stagehand-codemode/**'
       - 'examples/integrations/vercel/stagehand-codemode/**'
       - 'packages/stagehand-codemode/**'
@@ -14,6 +15,7 @@ on:
     paths:
       - '.github/workflows/stagehand-codemode.yml'
       - 'examples/integrations/crewai/stagehand-codemode/**'
+      - 'examples/integrations/langchain/stagehand-codemode/**'
       - 'examples/integrations/mastra/stagehand-codemode/**'
       - 'examples/integrations/vercel/stagehand-codemode/**'
       - 'packages/stagehand-codemode/**'
@@ -94,3 +96,25 @@ jobs:
       - run: pnpm --filter @browserbasehq/stagehand-codemode run build
       - run: python -m pip install -r examples/integrations/crewai/stagehand-codemode/requirements.txt
       - run: python examples/integrations/crewai/stagehand-codemode/smoke.py
+
+  deepagents:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.9.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: examples/integrations/langchain/stagehand-codemode/requirements.txt
+
+      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm --filter @browserbasehq/stagehand-codemode run build
+      - run: python -m pip install -r examples/integrations/langchain/stagehand-codemode/requirements.txt
+      - run: python examples/integrations/langchain/stagehand-codemode/smoke.py

--- a/examples/integrations/langchain/stagehand-codemode/README.md
+++ b/examples/integrations/langchain/stagehand-codemode/README.md
@@ -1,0 +1,13 @@
+# LangChain Deep Agents + Stagehand code mode
+
+This binding launches the local MCP over stdio and keeps one explicit LangChain MCP session open
+around the complete Deep Agent invocation.
+
+Do not replace the explicit `client.session()` plus `load_mcp_tools(session)` flow with
+`client.get_tools()`. LangChain documents that `get_tools()` creates a new session for each tool
+call; for a stdio server, that means a new process and a new browser every time.
+
+The shared Stagehand V4 syntax skill is loaded as the Deep Agent's `system_prompt` and is also
+included in the MCP tool description.
+
+See [`agent.py`](./agent.py).

--- a/examples/integrations/langchain/stagehand-codemode/agent.py
+++ b/examples/integrations/langchain/stagehand-codemode/agent.py
@@ -11,7 +11,7 @@ from langchain_mcp_adapters.tools import load_mcp_tools
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
 CLI_PATH = REPOSITORY_ROOT / "packages/stagehand-codemode/dist/cli.js"
-SKILL_PATH = REPOSITORY_ROOT / "packages/stagehand-codemode/STAGEHAND_CODEMODE_SKILL.md"
+SKILL_PATH = REPOSITORY_ROOT / "packages/stagehand-codemode/SKILL.md"
 STAGEHAND_CODEMODE_SKILL = SKILL_PATH.read_text().strip()
 
 

--- a/examples/integrations/langchain/stagehand-codemode/agent.py
+++ b/examples/integrations/langchain/stagehand-codemode/agent.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from deepagents import create_deep_agent
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.tools import load_mcp_tools
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+CLI_PATH = REPOSITORY_ROOT / "packages/stagehand-codemode/dist/cli.js"
+SKILL_PATH = REPOSITORY_ROOT / "packages/stagehand-codemode/STAGEHAND_CODEMODE_SKILL.md"
+STAGEHAND_CODEMODE_SKILL = SKILL_PATH.read_text().strip()
+
+
+async def run_stagehand_agent(prompt: str, model: str | Any = "openai:gpt-5-mini") -> dict[str, Any]:
+    client = MultiServerMCPClient(
+        {
+            "stagehand": {
+                "transport": "stdio",
+                "command": "node",
+                "args": [str(CLI_PATH)],
+                "env": dict(os.environ),
+            }
+        },
+        tool_name_prefix=False,
+        handle_tool_errors=True,
+    )
+
+    # An explicit session is required. client.get_tools() would start a fresh stdio
+    # process for each tool call and lose the browser between calls.
+    async with client.session("stagehand") as session:
+        tools = await load_mcp_tools(session)
+        code_tools = [tool for tool in tools if tool.name == "code_execute"]
+        if len(code_tools) != 1:
+            raise RuntimeError(f"Expected one code_execute tool, got {[tool.name for tool in tools]}")
+        agent = create_deep_agent(
+            model=model,
+            tools=code_tools,
+            system_prompt=STAGEHAND_CODEMODE_SKILL,
+        )
+        return await agent.ainvoke(
+            {"messages": [{"role": "user", "content": prompt}]},
+            config={"recursion_limit": 20},
+        )

--- a/examples/integrations/langchain/stagehand-codemode/agent.py
+++ b/examples/integrations/langchain/stagehand-codemode/agent.py
@@ -10,7 +10,7 @@ from langchain_mcp_adapters.tools import load_mcp_tools
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
-CLI_PATH = REPOSITORY_ROOT / "packages/stagehand-codemode/dist/cli.js"
+STDIO_SERVER_PATH = REPOSITORY_ROOT / "packages/stagehand-codemode/dist/stdio-server.js"
 SKILL_PATH = REPOSITORY_ROOT / "packages/stagehand-codemode/SKILL.md"
 STAGEHAND_CODEMODE_SKILL = SKILL_PATH.read_text().strip()
 
@@ -21,7 +21,7 @@ async def run_stagehand_agent(prompt: str, model: str | Any = "openai:gpt-5-mini
             "stagehand": {
                 "transport": "stdio",
                 "command": "node",
-                "args": [str(CLI_PATH)],
+                "args": [str(STDIO_SERVER_PATH)],
                 "env": dict(os.environ),
             }
         },

--- a/examples/integrations/langchain/stagehand-codemode/requirements.txt
+++ b/examples/integrations/langchain/stagehand-codemode/requirements.txt
@@ -1,0 +1,4 @@
+deepagents>=0.7.1,<1
+langchain-mcp-adapters>=0.3.1,<1
+langchain-openai>=1.2.1,<2
+mcp>=1.24.0,<2

--- a/examples/integrations/langchain/stagehand-codemode/smoke.py
+++ b/examples/integrations/langchain/stagehand-codemode/smoke.py
@@ -5,7 +5,7 @@ import asyncio
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.tools import load_mcp_tools
 
-from agent import CLI_PATH, STAGEHAND_CODEMODE_SKILL
+from agent import STDIO_SERVER_PATH, STAGEHAND_CODEMODE_SKILL
 
 
 async def main() -> None:
@@ -14,7 +14,7 @@ async def main() -> None:
             "stagehand": {
                 "transport": "stdio",
                 "command": "node",
-                "args": [str(CLI_PATH)],
+                "args": [str(STDIO_SERVER_PATH)],
             }
         }
     )

--- a/examples/integrations/langchain/stagehand-codemode/smoke.py
+++ b/examples/integrations/langchain/stagehand-codemode/smoke.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import asyncio
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.tools import load_mcp_tools
+
+from agent import CLI_PATH, STAGEHAND_CODEMODE_SKILL
+
+
+async def main() -> None:
+    client = MultiServerMCPClient(
+        {
+            "stagehand": {
+                "transport": "stdio",
+                "command": "node",
+                "args": [str(CLI_PATH)],
+            }
+        }
+    )
+    async with client.session("stagehand") as session:
+        tools = await load_mcp_tools(session)
+        assert [tool.name for tool in tools] == ["code_execute"]
+        assert "Stagehand V4 code-mode syntax" in (tools[0].description or "")
+        assert "stagehand.extract" in STAGEHAND_CODEMODE_SKILL
+        print("Deep Agents persistent stdio discovery PASS: code_execute")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- add a LangChain Deep Agents harness that launches the local Stagehand code-mode MCP over stdio
- hold one explicit MCP session open for the complete agent invocation so browser state survives tool calls
- load the shared Stagehand V4 syntax guide into the agent system prompt
- constrain the MCP Python dependency to the compatible 1.x line
- add a real persistent-session discovery smoke and an isolated Deep Agents CI job

## Stack

This PR is stacked on [the CrewAI integration](https://github.com/browserbase/integrations/pull/94). Its diff contains only the LangChain Deep Agents integration.

## Lifecycle

The harness opens `client.session("stagehand")`, loads tools from that session, and runs the complete agent invocation inside the same context. This explicit session is required because the convenience `get_tools()` path starts a new local MCP process for each tool call, which would discard browser state.

## E2E Test Matrix

| Command / flow                                                                                                                          | Observed output                                                                                                                                                     | Confidence / sufficiency                                                                                                                                                                                                              |
| --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Build the local code-mode package, then run the Deep Agents smoke in an isolated Python 3.12 environment with the reviewed requirements | The built server reported that it was listening on stdio and the persistent LangChain session reported `Deep Agents persistent stdio discovery PASS: code_execute`. | Proves the real LangChain MCP adapter can launch the reviewed local stdio server, keep an explicit session open, discover exactly one tool, and receive the shared syntax guide. It does not make a provider-dependent model request. |
| Resolve the Python requirements from scratch                                                                                            | Resolution selected `deepagents 0.7.4`, `langchain-mcp-adapters 0.3.1`, and `mcp 1.29.0`; the isolated smoke then passed.                                           | Proves the declared ranges form a compatible fresh environment and avoid the incompatible MCP 2.x API.                                                                                                                                |
| Targeted Prettier checks over the Deep Agents documentation and workflow                                                                | Completed without formatting differences.                                                                                                                           | Covers the changed Markdown and YAML surface; the executed Python smoke imports and runs every changed Python module.                                                                                                                 |
